### PR TITLE
Issue #2: add site-pack schema and validating fixture

### DIFF
--- a/data/fixtures/site-pack.sample.json
+++ b/data/fixtures/site-pack.sample.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "0.1.0",
+  "site_id": "candor",
+  "name": "Candor",
+  "world_body": "Mars",
+  "location_status": "real-region-scenario-site",
+  "coordinates": {
+    "latitude": 18.4,
+    "longitude": 77.5
+  },
+  "knowledge_layers": {
+    "observation": [
+      "Placeholder coordinates exist for scaffold purposes only."
+    ],
+    "inference": [
+      "A future verified candidate site will require terrain, hazard, and provenance updates."
+    ],
+    "scenario_assumption": [
+      "Candor is currently treated as a provisional Mars colony seed."
+    ]
+  },
+  "terrain_summary": "Placeholder terrain summary pending verified candidate site selection.",
+  "hazard_summary": "Placeholder hazard summary pending verified candidate site selection.",
+  "uncertainty_notes": [
+    "Coordinates are placeholders and must not be treated as authoritative."
+  ],
+  "provenance": [
+    "Scaffold fixture created locally for schema development."
+  ],
+  "revision_history": [
+    "v0.1.0 initial scaffold fixture"
+  ],
+  "notes": "This fixture exists to validate the schema and to preserve observation/inference/scenario-assumption separation."
+}

--- a/schemas/site-pack.schema.json
+++ b/schemas/site-pack.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://focus-earthlight.local/schemas/site-pack.schema.json",
+  "title": "SitePack",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "site_id",
+    "name",
+    "world_body",
+    "location_status",
+    "knowledge_layers",
+    "provenance",
+    "revision_history"
+  ],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "site_id": { "type": "string" },
+    "name": { "type": "string" },
+    "world_body": { "type": "string" },
+    "location_status": {
+      "type": "string",
+      "enum": ["real", "real-region-scenario-site", "hypothetical"]
+    },
+    "coordinates": {
+      "type": "object",
+      "required": ["latitude", "longitude"],
+      "properties": {
+        "latitude": { "type": "number" },
+        "longitude": { "type": "number" }
+      },
+      "additionalProperties": false
+    },
+    "knowledge_layers": {
+      "type": "object",
+      "required": ["observation", "inference", "scenario_assumption"],
+      "properties": {
+        "observation": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "inference": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "scenario_assumption": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "terrain_summary": { "type": "string" },
+    "hazard_summary": { "type": "string" },
+    "uncertainty_notes": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "provenance": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "revision_history": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/tools/validate_schemas.py
+++ b/tools/validate_schemas.py
@@ -9,6 +9,7 @@ def main() -> None:
     pairs = [
         ("data/fixtures/hypothesis-card.sample.json", "schemas/hypothesis-card.schema.json"),
         ("data/fixtures/world-state.sample.json", "schemas/world-state.schema.json"),
+        ("data/fixtures/site-pack.sample.json", "schemas/site-pack.schema.json"),
     ]
     for fixture_rel, schema_rel in pairs:
         fixture = json.loads((ROOT / fixture_rel).read_text())


### PR DESCRIPTION
Closes #2

Summary:
- added `site-pack` schema
- added validating `site-pack` sample fixture for Candor
- wired site-pack validation into `tools/validate_schemas.py`

Notes:
- fixture explicitly separates observation, inference, and scenario assumption
- current Candor coordinates remain placeholder scaffold values and are not authoritative
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR