### PR TITLE
Issue #3: add audit-record and event-object schemas

### DIFF
--- a/data/fixtures/audit-record.sample.json
+++ b/data/fixtures/audit-record.sample.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "0.1.0",
+  "id": "audit_001",
+  "record_type": "analysis",
+  "created_at": "2026-04-19T12:00:00Z",
+  "summary": "Initial audit record fixture for schema validation.",
+  "references": [
+    "hc_001"
+  ],
+  "outcome": "pending"
+}

--- a/data/fixtures/event-object.sample.json
+++ b/data/fixtures/event-object.sample.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "0.1.0",
+  "id": "event_001",
+  "title": "Greenhouse power fluctuation",
+  "event_type": "local_ops",
+  "summary": "A short power dip affected greenhouse lighting.",
+  "claims": [
+    "Greenhouse lighting was interrupted for 12 minutes."
+  ],
+  "source_ids": [
+    "source_001"
+  ]
+}

--- a/schemas/audit-record.schema.json
+++ b/schemas/audit-record.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://focus-earthlight.local/schemas/audit-record.schema.json",
+  "title": "AuditRecord",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "id",
+    "record_type",
+    "created_at",
+    "summary"
+  ],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "id": { "type": "string" },
+    "record_type": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "summary": { "type": "string" },
+    "references": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "outcome": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/schemas/event-object.schema.json
+++ b/schemas/event-object.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://focus-earthlight.local/schemas/event-object.schema.json",
+  "title": "EventObject",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "id",
+    "title",
+    "event_type",
+    "claims"
+  ],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "id": { "type": "string" },
+    "title": { "type": "string" },
+    "event_type": { "type": "string" },
+    "summary": { "type": "string" },
+    "claims": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "source_ids": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/validate_schemas.py
+++ b/tools/validate_schemas.py
@@ -10,6 +10,8 @@ def main() -> None:
         ("data/fixtures/hypothesis-card.sample.json", "schemas/hypothesis-card.schema.json"),
         ("data/fixtures/world-state.sample.json", "schemas/world-state.schema.json"),
         ("data/fixtures/site-pack.sample.json", "schemas/site-pack.schema.json"),
+        ("data/fixtures/audit-record.sample.json", "schemas/audit-record.schema.json"),
+        ("data/fixtures/event-object.sample.json", "schemas/event-object.schema.json"),
     ]
     for fixture_rel, schema_rel in pairs:
         fixture = json.loads((ROOT / fixture_rel).read_text())


### PR DESCRIPTION
Closes #3

Summary:
- added `audit-record` schema
- added `event-object` schema
- added validating sample fixtures for both
- wired both into `tools/validate_schemas.py`

Notes:
- `event-object` includes `source_ids` for provenance linkage
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR