### PR TITLE
Issue #6: add source-record schema and sample fixture

### DIFF
--- a/data/fixtures/source-record.sample.json
+++ b/data/fixtures/source-record.sample.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "0.1.0",
+  "id": "source_001",
+  "source_type": "news_article",
+  "title": "Placeholder Earth-side signal source",
+  "url": "https://example.org/source/001",
+  "provenance": "Sample source fixture for provenance linkage testing."
+}

--- a/schemas/source-record.schema.json
+++ b/schemas/source-record.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://focus-earthlight.local/schemas/source-record.schema.json",
+  "title": "SourceRecord",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "id",
+    "source_type",
+    "provenance"
+  ],
+  "properties": {
+    "schema_version": { "type": "string" },
+    "id": { "type": "string" },
+    "source_type": { "type": "string" },
+    "title": { "type": "string" },
+    "url": { "type": "string" },
+    "provenance": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/tools/validate_schemas.py
+++ b/tools/validate_schemas.py
@@ -12,6 +12,7 @@ def main() -> None:
         ("data/fixtures/site-pack.sample.json", "schemas/site-pack.schema.json"),
         ("data/fixtures/audit-record.sample.json", "schemas/audit-record.schema.json"),
         ("data/fixtures/event-object.sample.json", "schemas/event-object.schema.json"),
+        ("data/fixtures/source-record.sample.json", "schemas/source-record.schema.json"),
     ]
     for fixture_rel, schema_rel in pairs:
         fixture = json.loads((ROOT / fixture_rel).read_text())


### PR DESCRIPTION
Closes #6

Summary:
- added `source-record` schema
- added validating `source-record` sample fixture
- wired source-record validation into `tools/validate_schemas.py`

Notes:
- `event-object.source_ids` can now point at a concrete validated source fixture
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR