### PR TITLE
Issue #7: add issue templates and PR constitution checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,17 @@
+---
+name: Bug
+about: Report a bug or workflow break
+title: ""
+labels: bug
+assignees: ""
+---
+
+## What happened
+
+## Expected behavior
+
+## Steps to reproduce
+
+## Constitution implications
+
+## Environment

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,15 @@
+---
+name: Feature
+about: Add a feature or subsystem
+title: ""
+labels: feature
+assignees: ""
+---
+
+## Goal
+
+## Why
+
+## Constitution implications
+
+## Acceptance criteria

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+## What changed
+
+## Assumptions introduced
+
+## Remaining uncertainty
+
+## Tests run
+
+## Constitution check
+- [ ] Observation / inference separation preserved
+- [ ] Uncertainty visible
+- [ ] Provenance preserved
+- [ ] No covert compliance optimization


### PR DESCRIPTION
Closes #7

Summary:
- added feature issue template
- added bug issue template
- added PR template with constitution checklist

Notes:
- contributors are now prompted to state assumptions and remaining uncertainty
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR