### PR TITLE
Issue #15: add observatory models and fixture loading tests

### DIFF
--- a/observatory/models/audit_record.py
+++ b/observatory/models/audit_record.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class AuditRecord(BaseModel):
+    schema_version: str = "0.1.0"
+    id: str
+    record_type: str
+    created_at: str
+    summary: str
+    references: list[str] = []
+    outcome: str | None = None

--- a/observatory/models/event.py
+++ b/observatory/models/event.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class EventObject(BaseModel):
+    schema_version: str = "0.1.0"
+    id: str
+    title: str
+    event_type: str
+    summary: str | None = None
+    claims: list[str]
+    source_ids: list[str] = []

--- a/observatory/models/source_record.py
+++ b/observatory/models/source_record.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class SourceRecord(BaseModel):
+    schema_version: str = "0.1.0"
+    id: str
+    source_type: str
+    title: str | None = None
+    url: str | None = None
+    provenance: str

--- a/observatory/tests/test_models_fixture_loading.py
+++ b/observatory/tests/test_models_fixture_loading.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+from observatory.models.audit_record import AuditRecord
+from observatory.models.event import EventObject
+from observatory.models.source_record import SourceRecord
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "data" / "fixtures"
+
+
+def test_audit_record_fixture_loads() -> None:
+    data = json.loads((FIXTURES / "audit-record.sample.json").read_text())
+    model = AuditRecord.model_validate(data)
+    assert model.id == "audit_001"
+
+
+def test_event_object_fixture_loads() -> None:
+    data = json.loads((FIXTURES / "event-object.sample.json").read_text())
+    model = EventObject.model_validate(data)
+    assert model.id == "event_001"
+
+
+def test_source_record_fixture_loads() -> None:
+    data = json.loads((FIXTURES / "source-record.sample.json").read_text())
+    model = SourceRecord.model_validate(data)
+    assert model.id == "source_001"


### PR DESCRIPTION
Closes #15

Summary:
- added `AuditRecord`, `EventObject`, and `SourceRecord` Pydantic models
- added fixture-loading tests for all three models
- proved the current fixtures load cleanly into the matching Python models

Notes:
- this brings the Python model layer into line with the schemas added earlier
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR