### PR TITLE
Issue #17: add SitePack model and fixture-loading test

### DIFF
--- a/sim/models/site_pack.py
+++ b/sim/models/site_pack.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel
+
+
+class Coordinates(BaseModel):
+    latitude: float
+    longitude: float
+
+
+class KnowledgeLayers(BaseModel):
+    observation: list[str]
+    inference: list[str]
+    scenario_assumption: list[str]
+
+
+class SitePack(BaseModel):
+    schema_version: str = "0.1.0"
+    site_id: str
+    name: str
+    world_body: str
+    location_status: str
+    coordinates: Coordinates | None = None
+    knowledge_layers: KnowledgeLayers
+    terrain_summary: str | None = None
+    hazard_summary: str | None = None
+    uncertainty_notes: list[str] = []
+    provenance: list[str]
+    revision_history: list[str]
+    notes: str | None = None

--- a/sim/tests/test_site_pack_model.py
+++ b/sim/tests/test_site_pack_model.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+from sim.models.site_pack import SitePack
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "data" / "fixtures"
+
+
+def test_site_pack_fixture_loads() -> None:
+    data = json.loads((FIXTURES / "site-pack.sample.json").read_text())
+    model = SitePack.model_validate(data)
+    assert model.site_id == "candor"
+    assert model.location_status == "real-region-scenario-site"
+    assert "Coordinates are placeholders" in model.uncertainty_notes[0]


### PR DESCRIPTION
Closes #17

Summary:
- added `SitePack` Pydantic model in `sim/models/site_pack.py`
- added fixture-loading test in `sim/tests/test_site_pack_model.py`
- proved the current `site-pack.sample.json` loads cleanly into the Python model

Notes:
- the model includes explicit `observation`, `inference`, and `scenario_assumption` layers
- the test preserves the meaning that current Candor coordinates are placeholder scaffold values, not authoritative site truth
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR