### PR TITLE
Issue #19: add HypothesisCard model and fixture-loading test

### DIFF
--- a/observatory/models/hypothesis_card.py
+++ b/observatory/models/hypothesis_card.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+
+
+class HypothesisCard(BaseModel):
+    schema_version: str = "0.1.0"
+    id: str
+    claim: str
+    claim_type: str
+    status: str
+    confidence: float | None = None
+    evidence_for: list[str]
+    evidence_against: list[str]
+    alternative_hypotheses: list[str]
+    falsifiers: list[str]
+    review_date: str
+    unknowns: list[str] = []
+    notes: str | None = None

--- a/observatory/tests/test_hypothesis_card_model.py
+++ b/observatory/tests/test_hypothesis_card_model.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+from observatory.models.hypothesis_card import HypothesisCard
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "data" / "fixtures"
+
+
+def test_hypothesis_card_fixture_loads() -> None:
+    data = json.loads((FIXTURES / "hypothesis-card.sample.json").read_text())
+    model = HypothesisCard.model_validate(data)
+    assert model.id == "hc_001"
+    assert model.confidence == 0.45
+    assert len(model.alternative_hypotheses) > 0
+    assert len(model.falsifiers) > 0
+    assert model.review_date == "2026-05-01"


### PR DESCRIPTION
Closes #19

Summary:
- added `HypothesisCard` Pydantic model
- added fixture-loading test for `hypothesis-card.sample.json`
- proved confidence, alternatives, falsifiers, and review date load cleanly into the Python model

Notes:
- this brings the hypothesis-card schema into the Python model layer alongside the other observatory models
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR