### PR TITLE
Issue #23: add ingest-side EventObject fixture test

### DIFF
--- a/observatory/tests/test_eventobject_ingest_path.py
+++ b/observatory/tests/test_eventobject_ingest_path.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+from observatory.models.event import EventObject
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "data" / "fixtures"
+
+
+def test_event_object_fixture_loads_through_model() -> None:
+    data = json.loads((FIXTURES / "event-object.sample.json").read_text())
+    model = EventObject.model_validate(data)
+    assert model.id == "event_001"
+    assert model.event_type == "local_ops"
+    assert model.source_ids == ["source_001"]


### PR DESCRIPTION
Closes #23

Summary:
- added an ingest-side test for `EventObject`
- loads `data/fixtures/event-object.sample.json`
- validates it through `observatory.models.event.EventObject`
- keeps the test focused on the current fixture/model contract

Notes:
- this strengthens the observatory path without adding new ingestion complexity
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR