### PR TITLE
Issue #25: add ingest-side SourceRecord fixture test

### DIFF
--- a/observatory/tests/test_sourcerecord_ingest_path.py
+++ b/observatory/tests/test_sourcerecord_ingest_path.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+from observatory.models.source_record import SourceRecord
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "data" / "fixtures"
+
+
+def test_source_record_fixture_loads_through_model() -> None:
+    data = json.loads((FIXTURES / "source-record.sample.json").read_text())
+    model = SourceRecord.model_validate(data)
+    assert model.id == "source_001"
+    assert model.source_type == "news_article"
+    assert model.provenance == "Sample source fixture for provenance linkage testing."


### PR DESCRIPTION
Closes #25

Summary:
- added an ingest-side test for `SourceRecord`
- loads `data/fixtures/source-record.sample.json`
- validates it through `observatory.models.source_record.SourceRecord`
- keeps the test focused on the current fixture/model contract

Notes:
- this strengthens the observatory ingest path without adding new ingestion complexity
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR