### PR TITLE
Issue #27: add ingest-side HypothesisCard fixture test

### DIFF
--- a/observatory/tests/test_hypothesiscard_ingest_path.py
+++ b/observatory/tests/test_hypothesiscard_ingest_path.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+from observatory.models.hypothesis_card import HypothesisCard
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "data" / "fixtures"
+
+
+def test_hypothesis_card_fixture_loads_through_model() -> None:
+    data = json.loads((FIXTURES / "hypothesis-card.sample.json").read_text())
+    model = HypothesisCard.model_validate(data)
+    assert model.id == "hc_001"
+    assert model.claim_type == "causal"
+    assert model.review_date == "2026-05-01"


### PR DESCRIPTION
Closes #27

Summary:
- added an ingest-side test for `HypothesisCard`
- loads `data/fixtures/hypothesis-card.sample.json`
- validates it through `observatory.models.hypothesis_card.HypothesisCard`
- keeps the test focused on the current fixture/model contract

Notes:
- this strengthens the observatory ingest path without adding new ingestion complexity
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR