### PR TITLE
Issue #29: add ingest-side AuditRecord fixture test

### DIFF
--- a/observatory/tests/test_auditrecord_ingest_path.py
+++ b/observatory/tests/test_auditrecord_ingest_path.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+from observatory.models.audit_record import AuditRecord
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "data" / "fixtures"
+
+
+def test_audit_record_fixture_loads_through_model() -> None:
+    data = json.loads((FIXTURES / "audit-record.sample.json").read_text())
+    model = AuditRecord.model_validate(data)
+    assert model.id == "audit_001"
+    assert model.record_type == "analysis"
+    assert model.outcome == "pending"


### PR DESCRIPTION
Closes #29

Summary:
- added an ingest-side test for `AuditRecord`
- loads `data/fixtures/audit-record.sample.json`
- validates it through `observatory.models.audit_record.AuditRecord`
- keeps the test focused on the current fixture/model contract

Notes:
- this strengthens the observatory ingest path without adding new ingestion complexity
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR