### PR TITLE
Issue #30: add WorldState fixture-loading test

### DIFF
--- a/sim/tests/test_worldstate_model_fixture_loading.py
+++ b/sim/tests/test_worldstate_model_fixture_loading.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+from sim.models.world_state import WorldState
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "data" / "fixtures"
+
+
+def test_world_state_fixture_loads_through_model() -> None:
+    data = json.loads((FIXTURES / "world-state.sample.json").read_text())
+    model = WorldState.model_validate(data)
+    assert model.tick == 0
+    assert model.colony_name == "Candor"
+    assert model.air == 100.0
+    assert model.food == 100.0
+    assert model.power == 100.0
+    assert model.labor == 100.0
+    assert model.morale == 100.0


### PR DESCRIPTION
Closes #30

Summary:
- added a fixture-loading test for `WorldState`
- loads `data/fixtures/world-state.sample.json`
- validates it through `sim.models.world_state.WorldState`
- keeps the test focused on the current fixture/model contract

Notes:
- this strengthens the simulation model layer without changing simulation behavior
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR