### PR TITLE
Issue #32: add EventObject to SourceRecord linkage test

### DIFF
--- a/observatory/tests/test_event_source_linkage.py
+++ b/observatory/tests/test_event_source_linkage.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+from observatory.models.event import EventObject
+from observatory.models.source_record import SourceRecord
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "data" / "fixtures"
+
+
+def test_event_object_references_existing_source_record() -> None:
+    event_data = json.loads((FIXTURES / "event-object.sample.json").read_text())
+    source_data = json.loads((FIXTURES / "source-record.sample.json").read_text())
+
+    event = EventObject.model_validate(event_data)
+    source = SourceRecord.model_validate(source_data)
+
+    assert source.id in event.source_ids
+    assert event.source_ids == ["source_001"]
+    assert source.id == "source_001"


### PR DESCRIPTION
Closes #32

Summary:
- added a linkage test between `EventObject` and `SourceRecord`
- loads both `event-object.sample.json` and `source-record.sample.json`
- proves that the sample event references the existing sample source id
- keeps the test focused on the current fixture linkage only

Notes:
- this strengthens provenance confidence without adding new ingestion complexity
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR