### PR TITLE
Issue #31: export core observatory and sim models

### DIFF
--- a/observatory/models/__init__.py
+++ b/observatory/models/__init__.py
@@ -1,0 +1,11 @@
+from .audit_record import AuditRecord
+from .event import EventObject
+from .hypothesis_card import HypothesisCard
+from .source_record import SourceRecord
+
+__all__ = [
+    "AuditRecord",
+    "EventObject",
+    "HypothesisCard",
+    "SourceRecord",
+]

--- a/observatory/tests/test_model_exports.py
+++ b/observatory/tests/test_model_exports.py
@@ -1,0 +1,16 @@
+from observatory.models import AuditRecord, EventObject, HypothesisCard, SourceRecord
+from sim.models import Coordinates, KnowledgeLayers, SitePack, WorldState
+
+
+def test_observatory_model_exports_exist() -> None:
+    assert AuditRecord is not None
+    assert EventObject is not None
+    assert HypothesisCard is not None
+    assert SourceRecord is not None
+
+
+def test_sim_model_exports_exist() -> None:
+    assert Coordinates is not None
+    assert KnowledgeLayers is not None
+    assert SitePack is not None
+    assert WorldState is not None

--- a/sim/models/__init__.py
+++ b/sim/models/__init__.py
@@ -1,0 +1,9 @@
+from .site_pack import Coordinates, KnowledgeLayers, SitePack
+from .world_state import WorldState
+
+__all__ = [
+    "Coordinates",
+    "KnowledgeLayers",
+    "SitePack",
+    "WorldState",
+]


### PR DESCRIPTION
Closes #31

Summary:
- exported core observatory models from `observatory.models`
- exported core sim models from `sim.models`
- added a small import-proof test for the package exports

Notes:
- this improves import ergonomics without changing runtime behavior
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR