### PR TITLE
Issue #33: structure site-pack provenance

### DIFF
--- a/data/fixtures/site-pack.sample.json
+++ b/data/fixtures/site-pack.sample.json
@@ -25,7 +25,10 @@
     "Coordinates are placeholders and must not be treated as authoritative."
   ],
   "provenance": [
-    "Scaffold fixture created locally for schema development."
+    {
+      "kind": "scaffold",
+      "detail": "Sample site-pack fixture created locally for schema development."
+    }
   ],
   "revision_history": [
     "v0.1.0 initial scaffold fixture"

--- a/schemas/site-pack.schema.json
+++ b/schemas/site-pack.schema.json
@@ -58,7 +58,15 @@
     },
     "provenance": {
       "type": "array",
-      "items": { "type": "string" }
+      "items": {
+        "type": "object",
+        "required": ["kind", "detail"],
+        "properties": {
+          "kind": { "type": "string" },
+          "detail": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
     },
     "revision_history": {
       "type": "array",

--- a/sim/models/site_pack.py
+++ b/sim/models/site_pack.py
@@ -12,6 +12,11 @@ class KnowledgeLayers(BaseModel):
     scenario_assumption: list[str]
 
 
+class ProvenanceEntry(BaseModel):
+    kind: str
+    detail: str
+
+
 class SitePack(BaseModel):
     schema_version: str = "0.1.0"
     site_id: str
@@ -23,6 +28,6 @@ class SitePack(BaseModel):
     terrain_summary: str | None = None
     hazard_summary: str | None = None
     uncertainty_notes: list[str] = []
-    provenance: list[str]
+    provenance: list[ProvenanceEntry]
     revision_history: list[str]
     notes: str | None = None

--- a/sim/tests/test_site_pack_model.py
+++ b/sim/tests/test_site_pack_model.py
@@ -14,3 +14,4 @@ def test_site_pack_fixture_loads() -> None:
     assert model.site_id == "candor"
     assert model.location_status == "real-region-scenario-site"
     assert "Coordinates are placeholders" in model.uncertainty_notes[0]
+    assert model.provenance[0].kind == "scaffold"


### PR DESCRIPTION
Closes #33

Summary:
- structured `site-pack` provenance as explicit objects with `kind` and `detail`
- updated the sample site-pack fixture to use the new provenance shape
- updated the `SitePack` model to match the structured provenance layer
- updated the site-pack test to check the structured provenance entry

Notes:
- observation / inference / scenario assumption separation remains intact
- this is a small step toward more explicit site realism and provenance
- local untracked files `README1.md` and `docs/FOCUS Earthlight/` were intentionally not included in this PR