### PR TITLE
Issue #39: add AuditRecord to HypothesisCard linkage test

### DIFF
--- a/observatory/tests/test_audit_hypothesis_linkage.py
+++ b/observatory/tests/test_audit_hypothesis_linkage.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+
+from observatory.models.audit_record import AuditRecord
+from observatory.models.hypothesis_card import HypothesisCard
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / "data" / "fixtures"
+
+
+def test_audit_record_references_existing_hypothesis_card() -> None:
+    audit_data = json.loads((FIXTURES / "audit-record.sample.json").read_text())
+    hypothesis_data = json.loads((FIXTURES / "hypothesis-card.sample.json").read_text())
+
+    audit_record = AuditRecord.model_validate(audit_data)
+    hypothesis_card = HypothesisCard.model_validate(hypothesis_data)
+
+    assert hypothesis_card.id in audit_record.references
+    assert audit_record.references == ["hc_001"]
+    assert hypothesis_card.id == "hc_001"


### PR DESCRIPTION
Closes #39

Summary:
- added a focused observatory linkage test for `AuditRecord` and `HypothesisCard`
- loads the current `audit-record` and `hypothesis-card` fixtures through their models
- asserts that the audit reference resolves to the current hypothesis fixture ID

Tests run:
- `.venv/bin/python -m pytest observatory/tests/test_audit_hypothesis_linkage.py`

Assumptions introduced:
- the current fixture contract intentionally contains a single audit reference, `hc_001`, which should continue to resolve to the current hypothesis-card fixture