### PR TITLE
Issue #40: add SitePack JSON roundtrip test

### DIFF
--- a/sim/tests/test_site_pack_roundtrip.py
+++ b/sim/tests/test_site_pack_roundtrip.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+from jsonschema import validate
+
+from sim.models.site_pack import SitePack
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "data" / "fixtures" / "site-pack.sample.json"
+SCHEMA = ROOT / "schemas" / "site-pack.schema.json"
+
+
+def test_site_pack_json_roundtrip() -> None:
+    original_data = json.loads(FIXTURE.read_text())
+    model = SitePack.model_validate(original_data)
+
+    dumped_data = model.model_dump(mode="python")
+    schema = json.loads(SCHEMA.read_text())
+
+    validate(instance=dumped_data, schema=schema)
+
+    assert dumped_data["knowledge_layers"] == original_data["knowledge_layers"]
+    assert dumped_data["provenance"] == original_data["provenance"]
+    assert dumped_data["revision_history"] == original_data["revision_history"]


### PR DESCRIPTION
Closes #40

Summary:
- added a focused `SitePack` roundtrip test under `sim/tests/`
- loads the current site-pack fixture through `SitePack` and dumps it back to a plain payload
- validates the dumped payload against `schemas/site-pack.schema.json`
- asserts that `knowledge_layers`, `provenance`, and `revision_history` survive the roundtrip unchanged

Tests run:
- `.venv/bin/python -m pytest sim/tests/test_site_pack_roundtrip.py`

Assumptions introduced:
- the current `SitePack` roundtrip contract is based on `model_dump(mode="python")` preserving the fixture shape for `knowledge_layers`, `provenance`, and `revision_history` without additional normalization