### PR TITLE
Issue #41: add SitePack constitutional separation fixture test

### DIFF
--- a/sim/tests/test_site_pack_constitutional_separation.py
+++ b/sim/tests/test_site_pack_constitutional_separation.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+from sim.models.site_pack import SitePack
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "data" / "fixtures" / "site-pack.sample.json"
+
+
+def test_site_pack_preserves_knowledge_layer_separation() -> None:
+    data = json.loads(FIXTURE.read_text())
+    model = SitePack.model_validate(data)
+
+    assert model.knowledge_layers.observation
+    assert model.knowledge_layers.inference
+    assert model.knowledge_layers.scenario_assumption
+    assert "Coordinates are placeholders" in model.uncertainty_notes[0]
+    assert all(
+        "Coordinates are placeholders" not in inference
+        for inference in model.knowledge_layers.inference
+    )


### PR DESCRIPTION
Closes #41

Summary:
- added a focused `SitePack` fixture test under `sim/tests/`
- validates the current site-pack fixture through `SitePack`
- asserts that `observation`, `inference`, and `scenario_assumption` are all populated
- asserts that the coordinate-placeholder warning remains in `uncertainty_notes` and is not duplicated in the inference layer

Tests run:
- `.venv/bin/python -m pytest sim/tests/test_site_pack_constitutional_separation.py`

Assumptions introduced:
- the current fixture contract expresses the coordinate placeholder warning through `uncertainty_notes`, while the inference layer stays limited to forward-looking site-update statements