### PR TITLE
Issue #42: add pytest coverage for schema-validation helper

### DIFF
--- a/sim/tests/test_validate_schemas_tool.py
+++ b/sim/tests/test_validate_schemas_tool.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools" / "validate_schemas.py"
+
+
+def test_validate_schemas_tool_succeeds_for_current_fixtures() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "validated data/fixtures/hypothesis-card.sample.json" in result.stdout
+    assert "validated data/fixtures/world-state.sample.json" in result.stdout
+    assert "validated data/fixtures/site-pack.sample.json" in result.stdout
+    assert "validated data/fixtures/audit-record.sample.json" in result.stdout
+    assert "validated data/fixtures/event-object.sample.json" in result.stdout
+    assert "validated data/fixtures/source-record.sample.json" in result.stdout


### PR DESCRIPTION
Closes #42

Summary:
- added a focused pytest for `tools/validate_schemas.py` under `sim/tests/`
- runs the helper via Python subprocess against the current repo fixtures and schemas
- asserts that the command succeeds and emits validation lines for each current fixture/schema pair

Tests run:
- `.venv/bin/python -m pytest sim/tests/test_validate_schemas_tool.py`

Assumptions introduced:
- the helper continues to report success through stdout lines in the current `validated <fixture path>` format for each checked fixture